### PR TITLE
Pass context to lambdas

### DIFF
--- a/src/stencil/core.clj
+++ b/src/stencil/core.clj
@@ -32,13 +32,14 @@
               (node-render (:contents this) sb (conj context-stack val)))
             ;; Callable value -> Invoke it with the literal block of src text.
             (instance? clojure.lang.Fn ctx-val)
-            (let [lambda-return (ctx-val (:content (:attrs this)))]
+            (let [current-context (first context-stack)
+                  lambda-return (ctx-val (:content (:attrs this)) current-context)]
               ;; We have to manually parse because the spec says lambdas in
               ;; sections get parsed with the current parser delimiters.
               (.append sb (render (parse lambda-return
                                          (select-keys (:attrs this)
                                                       [:tag-open :tag-close]))
-                                         (first context-stack))))
+                                  current-context)))
             ;; Non-false non-list value -> Display content once.
             :else
             (node-render (:contents this) sb (conj context-stack ctx-val)))))


### PR DESCRIPTION
Not sure how anathema this would be, it's not clear to me if the mustache spec specifically prevents lambdas from accepting context. 

This makes it possible to write much more powerful lambdas, and I'm assuming there's a reason why you didn't include this in the first place. 

Just wanted to hear your thoughts.

Cheers!
Ignacio
