### PR TITLE
Ensure that keywords take precedence over strings

### DIFF
--- a/src/stencil/utils.clj
+++ b/src/stencil/utils.clj
@@ -29,6 +29,11 @@
       ;; unsuccessful in finding the key.
       nil)))
 
+(defn get-named
+  "Fixed version of quoin's get-named which doesn't get confused on nils values."
+  [map key]
+  (get map (map/contains-named? map key)))
+
 (defn context-get
   "Given a context stack and key, implements the rules for getting the
    key out of the context stack (see interpolation.yml in the spec). The
@@ -48,12 +53,12 @@
          ;; key left, we repeat the process using only the matching context as
          ;; the context stack.
          (if (next key)
-           (recur (list (map/get-named matching-context
-                                       (first key))) ;; Singleton ctx stack.
+           (recur (list (get-named matching-context
+                                   (first key))) ;; Singleton ctx stack.
                   (next key)
                   not-found)
            ;; Otherwise, we found the item!
-           (map/get-named matching-context (first key)))
+           (get-named matching-context (first key)))
          ;; Didn't find a matching context.
          not-found))))
 

--- a/test/stencil/test/core.clj
+++ b/test/stencil/test/core.clj
@@ -10,3 +10,9 @@
          (render-string "{{^a}}a{{b}}a{{/a}}" {:a [:b "11"]})))
   (is (= ""
          (render-string "{{^a}}a{{b}}a{{/a}}" {"a" ["b" "11"]}))))
+
+(deftest test-keywords-take-precedence-over-string-keys
+  (is (= ""
+         (render-string "{{a}}" {:a nil "a" "bar"})))
+  (is (= "foo"
+         (render-string "{{a}}" {:a "foo" "a" "bar"}))))


### PR DESCRIPTION
When there is a keyword and a string in the same map, the keyword is supposed to take precedence. However, if the value matching the keyword is nil, then Quoin's `get-named`'s use of `or` skips over the keyword's value. Using `contains-named?` fixes this.

I've submitted the patch to Quoin directly too - davidsantiago/quoin#4
