### PR TITLE
Improve core.cache-missing detection.

### DIFF
--- a/src/stencil/loader.clj
+++ b/src/stencil/loader.clj
@@ -42,6 +42,8 @@
   (atom (try
           (require 'clojure.core.cache)
           ((resolve 'clojure.core.cache/lru-cache-factory) {})
+          (catch ExceptionInInitializerError _
+            (CoreCacheUnavailableStub_SeeReadme.))
           (catch FileNotFoundException _
             (CoreCacheUnavailableStub_SeeReadme.)))))
 

--- a/src/stencil/utils.clj
+++ b/src/stencil/utils.clj
@@ -81,5 +81,7 @@
   (try
     (require 'clojure.core.cache)
     true
+    (catch ExceptionInInitializerError _
+      false)
     (catch FileNotFoundException _
       false)))


### PR DESCRIPTION
In some cases, (AOT-related?) attempting to require 'clojure.core.cache
does not result in a FileNotFoundException, but an
ExceptionInInitializerError instead. See
https://github.com/technomancy/leiningen/issues/1739.
