### PR TITLE
Make {{ . }} notation work with sets

### DIFF
--- a/src/stencil/ast.clj
+++ b/src/stencil/ast.clj
@@ -52,7 +52,9 @@
       ;; Per the spec, a function is truthy, so we should not render.
       (if (and (not (instance? clojure.lang.Fn ctx-val))
                (or (not ctx-val)
-                   (and (sequential? ctx-val)
+                   (and (or
+                         (sequential? ctx-val)
+                         (set? ctx-val))
                         (empty? ctx-val))))
         (render contents sb context-stack)))))
 (defn inverted-section [name attrs contents]

--- a/src/stencil/core.clj
+++ b/src/stencil/core.clj
@@ -23,11 +23,15 @@
   (render [this ^StringBuilder sb context-stack]
     (let [ctx-val (context-get context-stack (:name this))]
       (cond (or (not ctx-val) ;; "False" or the empty list -> do nothing.
-                (and (sequential? ctx-val)
+                (and (or
+                      (sequential? ctx-val)
+                      (set? ctx-val))
                      (empty? ctx-val)))
             nil
             ;; Non-empty list -> Display content once for each item in list.
-            (sequential? ctx-val)
+            (or
+             (sequential? ctx-val)
+             (set? ctx-val))
             (doseq [val ctx-val]
               ;; For each render, push the value to top of context stack.
               (node-render (:contents this) sb (conj context-stack val)))
@@ -89,4 +93,3 @@
    of args."
   [template-src data-map]
   (render (parse template-src) data-map))
-


### PR DESCRIPTION
Preciously when {{ . }} was used together with set it was producing
single output eg:

  > (render-string "{{# foo }} {{ . }} {{/ foo }}" {:foo #{1 2 3}})
  " #{1 3 2} "

Now previous will iterate over set processing one element at a time.
This means that example mentioned above will produce:

  " 1  3  2 "

Note, that the order of values is different and cannot be guaranteed.

Fixes #30