### PR TITLE
extend lambda to allow "a la carte" rendering

### DIFF
--- a/src/stencil/utils.clj
+++ b/src/stencil/utils.clj
@@ -62,18 +62,35 @@
    any. The content arg is the content of the tag being processed as a lambda in
    the template, and the context arg is the current context at this point in the
    processing. The latter will be ignored unless metadata directs otherwise.
- 
+
    Respected metadata:
      - :stencil/pass-context: passes the current context to the lambda as the
-       second arg."
-  ([lambda-fn context]
-     (if (:stencil/pass-context (meta lambda-fn))
-       (lambda-fn context)
-       (lambda-fn)))
-  ([lambda-fn content context]
-      (if (:stencil/pass-context (meta lambda-fn))
-        (lambda-fn content context)
-        (lambda-fn content))))
+       second arg.
+
+     - :stencil/pass-render: the lambda will receive the context
+       and the render function to be used in this context, respecting
+       custom section delimiters"
+  ([lambda-fn context render]
+   (cond
+     (:stencil/pass-render (meta lambda-fn))
+     (str (lambda-fn context render))
+
+     (:stencil/pass-context (meta lambda-fn))
+     (render (str (lambda-fn context)) context)
+
+     :else
+     (render (str (lambda-fn)) context)))
+
+  ([lambda-fn context render content]
+   (cond
+     (:stencil/pass-render (meta lambda-fn))
+     (str (lambda-fn content context render))
+
+     (:stencil/pass-context (meta lambda-fn))
+     (render (str (lambda-fn content context)) context)
+
+     :else
+     (render (str (lambda-fn content)) context))))
 
 (defn core-cache-present?
   "Returns true if the core.cache library is available, and false otherwise."


### PR DESCRIPTION
Hi, 


This allows to have better control over parsing/rendering in lambda functions. This is inspired by the examples in https://mustache.github.io/mustache.5.html. I know this is not clearly defined in the spec, but since the defaults do not change and this doesn't hurt the performance, this probably means it could be a welcome change.

snippet from the mustache.5 page

```mustache
Template:

{{#wrapped}}
  {{name}} is awesome.
{{/wrapped}}

```

JS:
```js
{
  "name": "Willy",
  "wrapped": function() {
    return function(text, render) {
      return "<b>" + render(text) + "</b>"
    }
  }
}

```

with this PR this would be translated into 
```clj
{:name "Willy"
 :wrapped
 ^{:stencil/pass-render true}
 (fn [text ctx render]
   (str "<b>" (render text) "</b>"))}
```

This PR doesn't change the current behavior of stencil, it's 100% backward compatible and should have no performance impact (actually using the new feature it's possible to make things a lot faster in most cases where rendering/parsing is not needed).

When pass-render is true in the lambda function metadata the function will receive both context and a render function, also by default no rendering/parsing is applied. This allow to have more control over the returned mustache code and mix dynamic/static content by interpolating raw strings and fragments wrapped in `render` calls. This is for instance very usefull to implement lambdas for syntax highlighting or lambdas that return json from a clojure object (since the {{ in the json would trigger errors).
This is also something fairly common in mustache libs (ex the java version supports this via a special Function type). 

There are 2 signatures, like :pass-context, one with content, one without. 
Tests were updated/added. 


Cheers