### PR TITLE
Removed Slingshot Dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,6 @@
              {:dependencies ^:replace [[org.clojure/clojure "1.3.0"]
                                        [scout "0.1.0"]
                                        [quoin "0.1.2"]
-                                       [slingshot "0.10.3"]
                                        [org.clojure/data.json "0.1.2"]]}
              :clj1.2 {:dependencies [[org.clojure/clojure "1.2.1"]]}
              :clj1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}

--- a/project.clj
+++ b/project.clj
@@ -4,16 +4,13 @@
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [scout "0.1.0"]
                  [quoin "0.1.2"]
-                 [slingshot "0.10.3"]
                  [org.clojure/core.cache "0.6.3"]]
   :profiles {:dev {:dependencies [[org.clojure/data.json "0.1.2"]]}
              :cacheless-test
-             {:dependencies ^:replace [[org.clojure/clojure "1.3.0"]
+             {:dependencies ^:replace [[org.clojure/clojure "1.4.0"]
                                        [scout "0.1.0"]
                                        [quoin "0.1.2"]
                                        [org.clojure/data.json "0.1.2"]]}
-             :clj1.2 {:dependencies [[org.clojure/clojure "1.2.1"]]}
-             :clj1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
              :clj1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}
              :clj1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}}
   :aliases {"all" ["with-profile" "dev:dev,clj1.4:dev,clj1.5"]

--- a/src/stencil/loader.clj
+++ b/src/stencil/loader.clj
@@ -1,7 +1,6 @@
 (ns stencil.loader
   (:refer-clojure :exclude [load])
   (:use [clojure.java.io :only [resource]]
-        [slingshot.slingshot :only [throw+]]
         [stencil.parser :exclude [partial]]
         [stencil.ast :exclude [partial]]
         [quoin.text :as qtext]
@@ -18,21 +17,24 @@
 (def ^{:private true} no-core-cache-msg
   "Could not load core.cache. To use Stencil without core.cache, you must first use set-cache to provide a map(-like object) to use as a cache, and consult the readme to make sure you fully understand the ramifications of running Stencil this way.")
 
+(defn- no-core-cache-ex []
+  (Exception. no-core-cache-msg))
+
 (deftype CoreCacheUnavailableStub_SeeReadme []
   clojure.lang.ILookup
-  (valAt [this key] (throw+ no-core-cache-msg))
-  (valAt [this key notFound] (throw+ no-core-cache-msg))
+  (valAt [this key] (throw (no-core-cache-ex)))
+  (valAt [this key notFound] (throw (no-core-cache-ex)))
   clojure.lang.IPersistentCollection
-  (count [this] (throw+ no-core-cache-msg))
-  (cons [this o] (throw+ no-core-cache-msg))
-  (empty [this] (throw+ no-core-cache-msg))
-  (equiv [this o] (throw+ no-core-cache-msg))
+  (count [this] (throw (no-core-cache-ex)))
+  (cons [this o] (throw (no-core-cache-ex)))
+  (empty [this] (throw (no-core-cache-ex)))
+  (equiv [this o] (throw (no-core-cache-ex)))
   clojure.lang.Seqable
-  (seq [this] (throw+ no-core-cache-msg))
+  (seq [this] (throw (no-core-cache-ex)))
   clojure.lang.Associative
-  (containsKey [this key] (throw+ no-core-cache-msg))
-  (entryAt [this key] (throw+ no-core-cache-msg))
-  (assoc [this key val] (throw+ no-core-cache-msg)))
+  (containsKey [this key] (throw (no-core-cache-ex)))
+  (entryAt [this key] (throw (no-core-cache-ex)))
+  (assoc [this key val] (throw (no-core-cache-ex))))
 
 ;; The dynamic template store just maps a template name to its source code.
 (def ^{:private true} dynamic-template-store (atom {}))


### PR DESCRIPTION
Removed slingshot by applying the following changes to change `throw+` usage to a normal `throw`:
  * `(throw+ a-string)` => `(throw (Exception. a-string))`
  * `(throw+ a-map a-string)` => `(throw (ex-info a-string a-map))`

### Considerations
  1. `ex-info` was only added in Clojure 1.4, so to do this requires dropping support for < 1.4 (changes made to project.clj, all remaining profile tests pass)
  2. In previous versions, values thrown with `throw+` weren't caught by stencil, so this change isn't backwards compatible.