### PR TITLE
adds Lambda shortcut syntax `{{(some text)}}` matches `:evaulate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,29 @@ An important advantage that `render-file` has over `render-string` is that
 the former will cache the results of parsing the file, and reuse the parsed
 AST on subsequent renders, greatly improving the speed.
 
+In Mustache, a Lambda can be invoked like so:
+
+    (render-string "How now {{#f}}cow{{#f}}"
+                   {:f (fn [text] (str "brown " text))})
+    "How now brown cow"
+
+Stencil provides a custom evaluation syntax:
+
+    {{(some text)}}
+
+which is shorthand for:
+
+    {{#evaluate}}(some text){{/evaluate}}
+
+This allows for concise Lambda invokation:
+
+    (render-string "Hello now {{(cow)}}"
+                   {:evaluate (fn [text] (str "brown " text))})
+    "How now brown (cow)"
+
+The parenthesis are preserved in the text so that the text may be read with
+`edn/read-string`.
+
 ## Lower Level APIs
 
 You can also manage things at a much lower level, if you prefer. In the
@@ -169,6 +192,11 @@ probably are some. If you run into anything, please let me know so I can fix
 it as soon as possible.
 
 ## Recently
+
+* Pending version 0.6.0.
+  - Adds a shortcut syntax for a Lambda `{{(some text)}}`
+    that will call a function in the context named `:evaluate`.
+    Thanks to [Timothy Pratley](https://github.com/timothypratley).
 
 * Released version 0.5.0.
   - Removed the dependency on slingshot, in favor of Clojure's built-in

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject stencil "0.5.0"
+(defproject stencil "0.6.0-SNAPSHOT"
   :description "Mustache in Clojure"
   :url "https://github.com/davidsantiago/stencil"
   :dependencies [[org.clojure/clojure "1.6.0"]

--- a/src/stencil/parser.clj
+++ b/src/stencil/parser.clj
@@ -228,15 +228,6 @@
                                        (let [form (str "(" tag-content)]
                                          (section (parse-tag-name "evaluate")
                                                   (assoc state :content form)
-                                                  #_{
-                                                     :content form
-                                                     :content-start (scan/position (if strip-whitespace?
-                                                                                     tag-position-scanner
-                                                                                     padding-scanner))
-                                                     :content-end (scan/position
-                                                                    (if strip-whitespace?
-                                                                      trailing-newline-scanner
-                                                                      close-scanner))}
                                                   form)))
                      state)
           \# (parser scanner

--- a/test/stencil/test/core.clj
+++ b/test/stencil/test/core.clj
@@ -1,4 +1,5 @@
 (ns stencil.test.core
+  (:require [clojure.edn :as edn])
   (:use clojure.test
         stencil.core))
 
@@ -16,3 +17,31 @@
 (deftest boolean-false-print-test
   (is (= "false" (render-string "{{a}}" {:a false})))
   (is (= "false" (render-string "{{{a}}}" {:a false}))))
+
+(deftest custom-evaluate-test
+  (testing "Special syntax {{()}} that behaves like a Lambda called evaluate"
+
+    (is (= "hello "
+           (render-string "hello {{(inc 1)}}" {}))
+        "produces empty string when no evaluate function exists in context")
+
+    (is (= "hello hi(inc 1)"
+           (render-string "hello {{(inc 1)}}"
+                          {:evaluate (fn [x]
+                                       (str "hi" x))}))
+        "when an evaluate function is provided, it is passed the text inside the tag")
+
+    (is (= "hello 2"
+           (render-string "hello {{(inc 1)}}"
+                          {:evaluate (fn [x]
+                                       (eval (read-string x)))}))
+        "the evaluate function can be interpreted as logic")
+
+    (is (thrown? Exception
+           (render-string "hello {{(drop tables)}}"
+                          {:evaluate (fn [x]
+                                       (let [[op a b] (edn/read-string x)]
+                                         (if (= op '+)
+                                           (+ a b)
+                                           (throw (ex-info "Unknown opperand" {:op op})))))}))
+        "custom evaluators should avoid eval for public facing inputs")))


### PR DESCRIPTION
See README and `stencil.test.core` for examples.

The motivation for this feature is to allow more concise use of
Lambda in templates.